### PR TITLE
Device registration bug in Messaging Service

### DIFF
--- a/src/com/backendless/Messaging.java
+++ b/src/com/backendless/Messaging.java
@@ -122,7 +122,7 @@ public final class Messaging
 
   public void registerDevice( String GCMSenderID, String channel, AsyncCallback<Void> callback )
   {
-    registerDevice( GCMSenderID, (channel == null || channel.equals( "" )) ? null : Arrays.asList( channel ), null, null );
+    registerDevice( GCMSenderID, (channel == null || channel.equals( "" )) ? null : Arrays.asList( channel ), null, callback );
   }
 
   public void registerDevice( String GCMSenderID, List<String> channels, Date expiration )


### PR DESCRIPTION
When calling async Backendless.Messaging.registerDevice(GCMsenderId, channel, callback), no response is received in callback - neither success, nor fault. This happens because in com.backendless.Messaging's method registerDevice( String GCMSenderID, String channel, AsyncCallback callback ) the callback is not passed further, instead null is passed. So I changed this method to pass a callback and now I can get a response from it.
