### PR TITLE
nextPage & previousPage always returned first page

### DIFF
--- a/src/com/backendless/geo/BackendlessGeoQuery.java
+++ b/src/com/backendless/geo/BackendlessGeoQuery.java
@@ -35,7 +35,7 @@ public class BackendlessGeoQuery implements IBackendlessQuery
   private boolean includeMeta = true;
   private Map<String, String> metadata = new HashMap<String, String>();
   private double[] searchRectangle;
-  private int pageSize = 0;
+  private int pageSize = 100;
   private int offset;
   private String whereClause;
   private Map<String, String> relativeFindMetadata = new HashMap<String, String>();


### PR DESCRIPTION
When calling nextPage or previousPage from BackendlessCollection object with BackendlessGeoQuery, the returned collection is still the first page. It happens because when calling one of this methods, the offset, which is passed further, is calculated as "offset+pageSize". But pageSize in the query is 0, so the offset is always 0 and always returns the first page.
