### PR TITLE
http://bugs.backendless.com/browse/BKNDLSS-11013 - fixed.

### DIFF
--- a/src/com/backendless/Media.java
+++ b/src/com/backendless/Media.java
@@ -309,7 +309,6 @@ public final class Media
     String url = protocol + wowzaAddress + streamPath + params;
     mediaPlayer.setDataSource( url );
     mediaPlayer.prepareAsync();
-    mediaPlayer.start();
 
   }
 


### PR DESCRIPTION
Calling method mediaPlayer.start() is incorrect and redundant - player can be started only when it's in state "Prepared". In this case "prepare async" method is called, and method "start()" calling is defined in it's callback "OnPreparedListener"