### PR TITLE
Avoid NPE when retrieving null relationsDepth

### DIFF
--- a/src/com/backendless/persistence/QueryOptions.java
+++ b/src/com/backendless/persistence/QueryOptions.java
@@ -99,7 +99,7 @@ public class QueryOptions
     this.relationsDepth = relationsDepth;
   }
 
-  public int getRelationsDepth()
+  public Integer getRelationsDepth()
   {
     return relationsDepth;
   }


### PR DESCRIPTION
The NPE leads to a broken cache inside of weborb's serializer - it merely can't see that there's a relationsDepth field and ignores it further.