### PR TITLE
Additional error info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 
 
 group 'com.backendless'
-version '4.3.7-snapshot'
+version '4.4.6-snapshot'
 archivesBaseName='backendless'
 
 
@@ -218,7 +218,7 @@ dependencies {
     provided fileTree(dir: 'libs', include: 'android.support.v4.jar')
     provided fileTree(dir: 'libs', include: 'FacebookSDK.jar')
     provided fileTree(dir: 'libs', include: 'maps.jar')
-    compile( group: "com.backendless", name: "commons", version: "4.4.1", changing: true) {
+    compile( group: "com.backendless", name: "commons", version: "4.4.6", changing: true) {
         exclude group: 'com.fasterxml.jackson.core'
     }
     compile( group: "weborb", name: "weborbclient", version: "5.1.0.210", changing: true)

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     provided fileTree(dir: 'libs', include: 'android.support.v4.jar')
     provided fileTree(dir: 'libs', include: 'FacebookSDK.jar')
     provided fileTree(dir: 'libs', include: 'maps.jar')
-    compile( group: "com.backendless", name: "commons", version: "4.4.0", changing: true) {
+    compile( group: "com.backendless", name: "commons", version: "4.4.1", changing: true) {
         exclude group: 'com.fasterxml.jackson.core'
     }
     compile( group: "weborb", name: "weborbclient", version: "5.1.0.210", changing: true)

--- a/src/com/backendless/Invoker.java
+++ b/src/com/backendless/Invoker.java
@@ -119,7 +119,9 @@ public class Invoker
 
     public void errorHandler( Fault fault )
     {
-      this.exception = new BackendlessException( new BackendlessFault( fault ) );
+      this.exception = (fault instanceof BackendlessFault)
+              ? new BackendlessException( (BackendlessFault) fault )
+              : new BackendlessException( new BackendlessFault( fault ) );
     }
 
     public Object getResult() throws BackendlessException

--- a/src/com/backendless/core/responder/AdaptingResponder.java
+++ b/src/com/backendless/core/responder/AdaptingResponder.java
@@ -31,6 +31,8 @@ import weborb.reader.StringType;
 import weborb.types.IAdaptingType;
 import weborb.v3types.ErrMessage;
 
+import java.util.Map;
+
 public class AdaptingResponder<E> implements IRawResponder
 {
   private Class<E> clazz;
@@ -112,11 +114,15 @@ public class AdaptingResponder<E> implements IRawResponder
   {
     if( responder != null )
     {
-      StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
-      StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
-      StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
+      final StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
+      final StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
+      final StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
+      final AnonymousObject extendedData = (AnonymousObject) bodyHolder.getProperties().get( "extendedData" );
 
-      Fault fault = new Fault( (String) faultMessage.defaultAdapt(), (String) faultDetail.defaultAdapt(), (String) faultCode.defaultAdapt() );
+      final Fault fault = new BackendlessFault( new Fault( (String) faultMessage.defaultAdapt(),
+                                                           (String) faultDetail.defaultAdapt(),
+                                                           (String) faultCode.defaultAdapt() ),
+                                                (Map<String, Object>) extendedData.defaultAdapt() );
       responder.errorHandler( fault );
     }
   }

--- a/src/com/backendless/core/responder/AdaptingResponder.java
+++ b/src/com/backendless/core/responder/AdaptingResponder.java
@@ -74,7 +74,10 @@ public class AdaptingResponder<E> implements IRawResponder
 
     if( ((IAdaptingType) adaptingType).getDefaultType().equals( ErrMessage.class ) )
     {
-      handledAsFault( (AnonymousObject) bodyHolder, nextResponder );
+      if( nextResponder != null )
+      {
+        nextResponder.errorHandler( adaptFault( (AnonymousObject) bodyHolder ) );
+      }
     }
     else
     {
@@ -110,20 +113,16 @@ public class AdaptingResponder<E> implements IRawResponder
     return clazz;
   }
 
-  private void handledAsFault( AnonymousObject bodyHolder, IResponder responder )
+  public static BackendlessFault adaptFault( AnonymousObject bodyHolder )
   {
-    if( responder != null )
-    {
-      final StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
-      final StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
-      final StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
-      final AnonymousObject extendedData = (AnonymousObject) bodyHolder.getProperties().get( "extendedData" );
+    final StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
+    final StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
+    final StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
+    final AnonymousObject extendedData = (AnonymousObject) bodyHolder.getProperties().get( "extendedData" );
 
-      final Fault fault = new BackendlessFault( new Fault( (String) faultMessage.defaultAdapt(),
-                                                           (String) faultDetail.defaultAdapt(),
-                                                           (String) faultCode.defaultAdapt() ),
-                                                (Map<String, Object>) extendedData.defaultAdapt() );
-      responder.errorHandler( fault );
-    }
+    return new BackendlessFault( new Fault( (String) faultMessage.defaultAdapt(),
+                                            (String) faultDetail.defaultAdapt(),
+                                            (String) faultCode.defaultAdapt() ),
+                                 (Map<String, Object>) extendedData.defaultAdapt() );
   }
 }

--- a/src/com/backendless/exceptions/BackendlessException.java
+++ b/src/com/backendless/exceptions/BackendlessException.java
@@ -18,6 +18,8 @@
 
 package com.backendless.exceptions;
 
+import java.util.Map;
+
 public class BackendlessException extends RuntimeException
 {
   private static final long serialVersionUID = -7537447408166433783L;
@@ -101,6 +103,11 @@ public class BackendlessException extends RuntimeException
     return backendlessFault.getDetail();
   }
 
+  public Map<String, Object> getExtendedData()
+  {
+    return backendlessFault.getExtendedData();
+  }
+
   @Override
   public String toString()
   {
@@ -108,6 +115,7 @@ public class BackendlessException extends RuntimeException
     sb.append( getClass().getSimpleName() );
     sb.append( "{ code: '" ).append( getCode() ).append( '\'' );
     sb.append( ", message: '" ).append( getMessage() ).append( '\'' );
+    sb.append( ", extendedData: '").append( getExtendedData() ).append( '\'' );
     sb.append( " }" );
     return sb.toString();
   }

--- a/src/com/backendless/exceptions/BackendlessFault.java
+++ b/src/com/backendless/exceptions/BackendlessFault.java
@@ -20,31 +20,57 @@ package com.backendless.exceptions;
 
 import weborb.client.Fault;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class BackendlessFault extends Fault
 {
+  private final Map<String, Object> extendedData;
+
   public BackendlessFault( Fault fault )
   {
     super( fault.getMessage(), fault.getDetail(), fault.getCode() );
+    this.extendedData = new HashMap<>();
+  }
+
+  public BackendlessFault( Fault fault, Map<String, Object> extendedData )
+  {
+    super( fault.getMessage(), fault.getDetail(), fault.getCode() );
+    this.extendedData = extendedData;
+  }
+
+  public BackendlessFault( BackendlessFault fault )
+  {
+    super( fault.getMessage(), fault.getDetail(), fault.getCode() );
+    this.extendedData = fault.getExtendedData();
   }
 
   public BackendlessFault( String faultCode, String message )
   {
     super( message, null, faultCode );
+    this.extendedData = new HashMap<>();
   }
 
   public BackendlessFault( String message )
   {
     super( message, null );
+    this.extendedData = new HashMap<>();
   }
 
   public BackendlessFault( BackendlessException e )
   {
     super( e.getMessage(), e.getDetail(), e.getCode() );
+    this.extendedData = e.getExtendedData();
   }
 
   public BackendlessFault( Throwable e )
   {
     this( ExceptionMessage.ILLEGAL_ARGUMENT_EXCEPTION, e.getMessage() );
+  }
+
+  public Map<String, Object> getExtendedData()
+  {
+    return extendedData;
   }
 
   @Override
@@ -54,6 +80,7 @@ public class BackendlessFault extends Fault
             "{ code: '" + getCode() + '\'' +
             ", message: '" + getMessage() + '\'' +
             ", detail: '" + getDetail() + '\'' +
+            ", extendedData: '" + getExtendedData() + '\'' +
             " }";
   }
 }

--- a/src/com/backendless/persistence/MapDrivenDataStore.java
+++ b/src/com/backendless/persistence/MapDrivenDataStore.java
@@ -756,11 +756,15 @@ public class MapDrivenDataStore implements IDataStore<Map>
     {
       if( responder != null )
       {
-        StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
-        StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
-        StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
+        final StringType faultMessage = (StringType) bodyHolder.getProperties().get( "faultString" );
+        final StringType faultDetail = (StringType) bodyHolder.getProperties().get( "faultDetail" );
+        final StringType faultCode = (StringType) bodyHolder.getProperties().get( "faultCode" );
+        final AnonymousObject extendedData = (AnonymousObject) bodyHolder.getProperties().get( "extendedData" );
 
-        Fault fault = new Fault( (String) faultMessage.defaultAdapt(), (String) faultDetail.defaultAdapt(), (String) faultCode.defaultAdapt() );
+        final Fault fault = new BackendlessFault( new Fault( (String) faultMessage.defaultAdapt(),
+                                                             (String) faultDetail.defaultAdapt(),
+                                                             (String) faultCode.defaultAdapt() ),
+                                                  (Map<String, Object>) extendedData.defaultAdapt() );
         responder.errorHandler( fault );
       }
     }


### PR DESCRIPTION
`BackendlessException` and `BackendlessFault` now have method `getExtendedData()` which returns `Map<String, Object>` with additional parseable error data. For example, when saving an object without required field, the `extendedData` fields will contain a map `"propeties" -> ["requiredOne"]`.