### PR TITLE
BKNDLSS-19105 Obtain headers from intent in BackendlessFCMService

### DIFF
--- a/src/com/backendless/push/BackendlessFCMService.java
+++ b/src/com/backendless/push/BackendlessFCMService.java
@@ -184,7 +184,7 @@ public class BackendlessFCMService extends FirebaseMessagingService
 
     Intent notificationIntent = context.getPackageManager().getLaunchIntentForPackage( context.getApplicationInfo().packageName );
     notificationIntent.putExtras( newBundle );
-    PendingIntent contentIntent = PendingIntent.getActivity( context, 0, notificationIntent, 0 );
+    PendingIntent contentIntent = PendingIntent.getActivity( context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT );
 
     notificationBuilder.setContentIntent( contentIntent )
             .setSmallIcon( appIcon )


### PR DESCRIPTION
Добавил флаг 
``` java 
FLAG_UPDATE_CURRENT 
``` 
в `PendingIntent` при создании оповещения в `BackendlessFCMService` , поскольку по умолчанию Android в целях оптимизации всегда переиспользует предыдущий `PendingIntent`, если такой существует, и соответственно не обновляет поле exras в нем.

В свою очередь, согласно [оффициальной документации](https://developer.android.com/reference/android/app/PendingIntent.html#FLAG_UPDATE_CURRENT):

> Flag FLAG_UPDATE_CURRENT indicating that if the described PendingIntent already exists, then keep it but **replace its extra data** with what is in this new Intent.

