### PR TITLE
BKNDLSS-19105 Obtain headers from intent in BackendlessFCMService

### DIFF
--- a/src/com/backendless/push/BackendlessFCMService.java
+++ b/src/com/backendless/push/BackendlessFCMService.java
@@ -184,7 +184,7 @@ public class BackendlessFCMService extends FirebaseMessagingService
 
     Intent notificationIntent = context.getPackageManager().getLaunchIntentForPackage( context.getApplicationInfo().packageName );
     notificationIntent.putExtras( newBundle );
-    PendingIntent contentIntent = PendingIntent.getActivity( context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT );
+    PendingIntent contentIntent = PendingIntent.getActivity( context, notificationId * 3, notificationIntent, 0 );
 
     notificationBuilder.setContentIntent( contentIntent )
             .setSmallIcon( appIcon )


### PR DESCRIPTION
Fix notifications `extra` fileld updating:

Remove the unnecessary flag `FLAG_UPDATE_CURRENT`.
Set `requestCode` value to `notificationId * 3` to create unique PendingIntent for each notification.