### PR TITLE
[BKNDLSS-19478] Fix Schema Definition Retrieving

### DIFF
--- a/src/com/backendless/property/AbstractProperty.java
+++ b/src/com/backendless/property/AbstractProperty.java
@@ -26,7 +26,7 @@ public abstract class AbstractProperty
 
   public String getName()
   {
-    return new String( name );
+    return name;
   }
 
   public void setName( String name )

--- a/src/com/backendless/property/ObjectProperty.java
+++ b/src/com/backendless/property/ObjectProperty.java
@@ -41,7 +41,7 @@ public class ObjectProperty extends AbstractProperty
 
   public String getRelatedTable()
   {
-    return new String( relatedTable );
+    return relatedTable;
   }
 
   public void setRelatedTable( String relatedTable )


### PR DESCRIPTION
Remove redundant String constructors inside `name` and `relatedTable` getters to avoid NullPointerException if these fields are null.